### PR TITLE
Support passing additional arguments to the Q# program

### DIFF
--- a/src/quantum/azext_quantum/_params.py
+++ b/src/quantum/azext_quantum/_params.py
@@ -20,3 +20,6 @@ def load_arguments(self, _):
 
     with self.argument_context('quantum job') as c:
         c.argument('workspace_name', workspace_name_type)
+
+    with self.argument_context('quantum job submit') as c:
+        c.positional('program_args', nargs='*')

--- a/src/quantum/azext_quantum/operations/job.py
+++ b/src/quantum/azext_quantum/operations/job.py
@@ -19,7 +19,7 @@ def show(cmd, job_id, resource_group_name=None, workspace_name=None):
     return client.get(job_id)
 
 
-def submit(cmd, resource_group_name=None, workspace_name=None, target_id=None, build=False, *kwargs):
+def submit(cmd, resource_group_name=None, workspace_name=None, target_id=None, build=False, program_args=None):
     import os
 
     def is_env(name):
@@ -70,6 +70,9 @@ def submit(cmd, resource_group_name=None, workspace_name=None, target_id=None, b
 
     args.append("--base-uri")
     args.append(base_url())
+
+    if program_args:
+        args.extend(program_args)
 
     import subprocess
     result = subprocess.run(args, stdout=subprocess.PIPE, check=False)

--- a/src/quantum/azext_quantum/operations/job.py
+++ b/src/quantum/azext_quantum/operations/job.py
@@ -19,7 +19,7 @@ def show(cmd, job_id, resource_group_name=None, workspace_name=None):
     return client.get(job_id)
 
 
-def submit(cmd, resource_group_name=None, workspace_name=None, target_id=None, build=False, program_args=None):
+def submit(cmd, program_args, resource_group_name=None, workspace_name=None, target_id=None, build=False):
     import os
 
     def is_env(name):
@@ -71,8 +71,7 @@ def submit(cmd, resource_group_name=None, workspace_name=None, target_id=None, b
     args.append("--base-uri")
     args.append(base_url())
 
-    if program_args:
-        args.extend(program_args)
+    args.extend(program_args)
 
     import subprocess
     result = subprocess.run(args, stdout=subprocess.PIPE, check=False)


### PR DESCRIPTION
It should pick up everything after the `--`, for example:

```
az quantum job submit --target-id mytarget -- --foo aaa --bar bbb
```