### PR TITLE
Adding implementation of 'az quantum workspace delete' command

### DIFF
--- a/src/quantum/azext_quantum/_help.py
+++ b/src/quantum/azext_quantum/_help.py
@@ -54,6 +54,9 @@ helps['quantum workspace'] = """
       - name: Get the list of Azure Quantum workspaces available
         text: |-
             az quantum workspace list
+      - name: Delete an Azure Quantum workspace that is no longer being used
+        text: |-
+            az quantum workspace delete -g MyResourceGroup -w MyWorkspace
       - name: Select a default Azure Quantum workspace for future commands
         text: |-
             az quantum workspace set -g MyResourceGroup -w MyWorkspace

--- a/src/quantum/azext_quantum/commands.py
+++ b/src/quantum/azext_quantum/commands.py
@@ -82,6 +82,7 @@ def load_command_table(self, _):
     target_ops = CliCommandType(operations_tmpl='azext_quantum.operations.target#{}')
 
     with self.command_group('quantum workspace', workspace_ops) as w:
+        w.command('delete', 'delete', validator=validate_workspace_info)
         w.command('list', 'list')
         w.command('show', 'show', validator=validate_workspace_info)
         w.command('set', 'set', validator=validate_workspace_info)

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
@@ -49,6 +49,6 @@ class QuantumScenarioTest(ScenarioTest):
         # delete
         ## TODO: This test is disabled until the 'create' command is added.
         # self.cmd(f'az quantum workspace delete -g {TEST_RG} -w {TEST_WORKSPACE_CREATE_DELETE} -o json'), checks=[
-        #    self.check("name", TEST_WORKSPACE),
+        #    self.check("name", TEST_WORKSPACE_CREATE_DELETE),
         #    self.check("provisioningState", )
         #])

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
@@ -45,3 +45,10 @@ class QuantumScenarioTest(ScenarioTest):
 
         # clear
         self.cmd(f'az quantum workspace clear')
+
+        # delete
+        ## TODO: This test is disabled until the 'create' command is added.
+        # self.cmd(f'az quantum workspace delete -g {TEST_RG} -w {TEST_WORKSPACE_CREATE_DELETE} -o json'), checks=[
+        #    self.check("name", TEST_WORKSPACE),
+        #    self.check("provisioningState", )
+        #])

--- a/src/quantum/azext_quantum/tests/latest/utils.py
+++ b/src/quantum/azext_quantum/tests/latest/utils.py
@@ -6,6 +6,7 @@
 TEST_SUBS = "677fc922-91d0-4bf6-9b06-4274d319a0fa"
 TEST_RG = 'aqua-provider-validator'
 TEST_WORKSPACE = 'validator-workspace-westus'
+TEST_WORKSPACE_CREATE_DELETE = 'validator-workspace-crdl-westus'
 
 
 def is_private_preview_subscription(scenario):

--- a/src/quantum/azext_quantum/vendored_sdks/azure_mgmt_quantum/operations/workspaces_operations.py
+++ b/src/quantum/azext_quantum/vendored_sdks/azure_mgmt_quantum/operations/workspaces_operations.py
@@ -297,7 +297,7 @@ class WorkspacesOperations(object):
         request = self._client.delete(url, query_parameters, header_parameters)
         response = self._client.send(request, stream=False, **operation_config)
 
-        if response.status_code not in [200, 201]:
+        if response.status_code not in [200, 201, 202]:
             raise models.ErrorResponseException(self._deserialize, response)
 
         deserialized = None

--- a/src/quantum/azext_quantum/vendored_sdks/azure_mgmt_quantum/operations/workspaces_operations.py
+++ b/src/quantum/azext_quantum/vendored_sdks/azure_mgmt_quantum/operations/workspaces_operations.py
@@ -297,7 +297,7 @@ class WorkspacesOperations(object):
         request = self._client.delete(url, query_parameters, header_parameters)
         response = self._client.send(request, stream=False, **operation_config)
 
-        if response.status_code not in [200, 201, 202]:
+        if response.status_code not in [200, 201]:
             raise models.ErrorResponseException(self._deserialize, response)
 
         deserialized = None

--- a/src/quantum/setup.py
+++ b/src/quantum/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '0.12.2010.1300'
+VERSION = '0.12.2010.1901'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/src/quantum/setup.py
+++ b/src/quantum/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '0.11.2006.4'
+VERSION = '0.12.2010.1300'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
This change adds the 'az quantum workspace delete' command to the Azure CLI Quantum extension.

The command can be used to delete a provided workspace using parameters -g and -w, or it will delete the default workspace it set when called without arguments.

Command
    az quantum workspace delete : Deletes the given (or current) Azure Quantum workspace.

Arguments
    --resource-group -g : Name of resource group. You can configure the default group using `az
                          configure --defaults group=<name>`.
    --workspace-name -w : Name of the Quantum Workspace. You can configure the default workspace
                          using `az quantum workspace set`.