### PR TITLE
Adding implementation of 'az quantum workspace create' command.

### DIFF
--- a/src/quantum/azext_quantum/_help.py
+++ b/src/quantum/azext_quantum/_help.py
@@ -54,6 +54,9 @@ helps['quantum workspace'] = """
       - name: Get the list of Azure Quantum workspaces available
         text: |-
             az quantum workspace list
+      - name: Create a new Azure Quantum workspace
+        text: |-
+            az quantum workspace create -g MyResourceGroup -w MyWorkspace -l MyLocation -sa MyStorageAccountName
       - name: Delete an Azure Quantum workspace that is no longer being used
         text: |-
             az quantum workspace delete -g MyResourceGroup -w MyWorkspace

--- a/src/quantum/azext_quantum/_params.py
+++ b/src/quantum/azext_quantum/_params.py
@@ -9,6 +9,7 @@ from knack.arguments import CLIArgumentType
 
 def load_arguments(self, _):
     workspace_name_type = CLIArgumentType(options_list=['--workspace-name', '-w'], help='Name of the Quantum Workspace. You can configure the default workspace using `az quantum workspace set`.', id_part=None, required=False)
+    storage_account_name_type = CLIArgumentType(options_list=['--storage_account', '-sa'], help='Name of the storage account to be used by a quantum workspace.')
     program_args_type = CLIArgumentType(nargs='*', help='List of arguments expected by the Q# operation specified as --name=value after `--`.')
     target_id_type = CLIArgumentType(options_list=['--target-id', '-t'], help='Target id.')
     project_type = CLIArgumentType(help='The location of the Q# project to submit. Defaults to current folder.')
@@ -19,6 +20,7 @@ def load_arguments(self, _):
 
     with self.argument_context('quantum workspace') as c:
         c.argument('workspace_name', workspace_name_type)
+        c.argument('storage_account', storage_account_name_type)
 
     with self.argument_context('quantum target') as c:
         c.argument('workspace_name', workspace_name_type)

--- a/src/quantum/azext_quantum/commands.py
+++ b/src/quantum/azext_quantum/commands.py
@@ -82,6 +82,7 @@ def load_command_table(self, _):
     target_ops = CliCommandType(operations_tmpl='azext_quantum.operations.target#{}')
 
     with self.command_group('quantum workspace', workspace_ops) as w:
+        w.command('create', 'create', validator=validate_workspace_info)
         w.command('delete', 'delete', validator=validate_workspace_info)
         w.command('list', 'list')
         w.command('show', 'show', validator=validate_workspace_info)

--- a/src/quantum/azext_quantum/commands.py
+++ b/src/quantum/azext_quantum/commands.py
@@ -82,7 +82,7 @@ def load_command_table(self, _):
     target_ops = CliCommandType(operations_tmpl='azext_quantum.operations.target#{}')
 
     with self.command_group('quantum workspace', workspace_ops) as w:
-        w.command('create', 'create', validator=validate_workspace_info)
+        w.command('create', 'create')
         w.command('delete', 'delete', validator=validate_workspace_info)
         w.command('list', 'list')
         w.command('show', 'show', validator=validate_workspace_info)

--- a/src/quantum/azext_quantum/operations/workspace.py
+++ b/src/quantum/azext_quantum/operations/workspace.py
@@ -8,6 +8,8 @@
 from knack.util import CLIError
 
 from .._client_factory import cf_workspaces
+from ..vendored_sdks.azure_mgmt_quantum.models import QuantumWorkspace
+from ..vendored_sdks.azure_mgmt_quantum.models import Provider
 
 
 class WorkspaceInfo(object):
@@ -42,6 +44,31 @@ class WorkspaceInfo(object):
         with ConfiguredDefaultSetter(cmd.cli_ctx.config, False):
             cmd.cli_ctx.config.set_value('quantum', 'group', self.resource_group)
             cmd.cli_ctx.config.set_value('quantum', 'workspace', self.name)
+
+def create(cmd, resource_group_name=None, workspace_name=None):
+    """
+    Creates a new Azure Quantum workspace.
+    """
+    print("Create attempted.")
+    client = cf_workspaces(cmd.cli_ctx)
+    info = WorkspaceInfo(cmd, resource_group_name, workspace_name)
+    if (not info.resource_group) or (not info.name):
+        raise CLIError("Please run 'az quantum workspace set' first to select a default Quantum Workspace.")
+    # Default provider
+    prov = Provider()
+    prov.provider_id = "Microsoft"
+    prov.provider_sku = "Basic"
+    # Create a Quantum Workspace object and set the required properties
+    qw = QuantumWorkspace()
+    qw.location = "West US"
+    qw.providers = [prov]
+    qw.storage_account = "/subscriptions/916dfd6d-030c-4bd9-b579-7bb6d1926e97/resourceGroups/aqua-testing-westus2/providers/Microsoft.Storage/storageAccounts/ricardoeaqd01"
+    print(qw)
+    print("Create attempted. 2")
+    client.create_and_update(info.resource_group, info.name, qw, raw=True, polling=False)
+    return qw
+
+
 
 def delete(cmd, resource_group_name=None, workspace_name=None):
     """

--- a/src/quantum/azext_quantum/operations/workspace.py
+++ b/src/quantum/azext_quantum/operations/workspace.py
@@ -58,8 +58,8 @@ def get_basic_quantum_workspace(location, info, storage_account):
     # Allow the system to assign the workspace identity
     qw.identity = QuantumWorkspaceIdentity()
     qw.identity.type = "SystemAssigned"
-    qw.location=location
-    qw.storage_account = "/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Storage/storageAccounts/{2}".format(info.subscription, info.resource_group, storage_account)
+    qw.location = location
+    qw.storage_account = f"/subscriptions/{info.subscription}/resourceGroups/{info.resource_group}/providers/Microsoft.Storage/storageAccounts/{storage_account}"
     return qw
 
 

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
@@ -46,9 +46,14 @@ class QuantumScenarioTest(ScenarioTest):
         # clear
         self.cmd(f'az quantum workspace clear')
 
+        # create
+         self.cmd(f'az quantum workspace create -g {TEST_RG} -w {TEST_WORKSPACE_CREATE_DELETE} -l {TEST_WORKSPACE_LOCATION} -sa {TEST_WORKSPACE_SA} -o json'), checks=[
+            self.check("name", TEST_WORKSPACE_CREATE_DELETE),
+            self.check("provisioningState", "Succeeded")
+        ])
+
         # delete
-        ## TODO: This test is disabled until the 'create' command is added.
-        # self.cmd(f'az quantum workspace delete -g {TEST_RG} -w {TEST_WORKSPACE_CREATE_DELETE} -o json'), checks=[
-        #    self.check("name", TEST_WORKSPACE_CREATE_DELETE),
-        #    self.check("provisioningState", )
-        #])
+         self.cmd(f'az quantum workspace delete -g {TEST_RG} -w {TEST_WORKSPACE_CREATE_DELETE} -o json'), checks=[
+            self.check("name", TEST_WORKSPACE_CREATE_DELETE),
+            self.check("provisioningState", "Deleting")
+        ])

--- a/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
+++ b/src/quantum/azext_quantum/tests/latest/test_quantum_workspace.py
@@ -47,13 +47,13 @@ class QuantumScenarioTest(ScenarioTest):
         self.cmd(f'az quantum workspace clear')
 
         # create
-         self.cmd(f'az quantum workspace create -g {TEST_RG} -w {TEST_WORKSPACE_CREATE_DELETE} -l {TEST_WORKSPACE_LOCATION} -sa {TEST_WORKSPACE_SA} -o json'), checks=[
+        self.cmd(f'az quantum workspace create -g {TEST_RG} -w {TEST_WORKSPACE_CREATE_DELETE} -l {TEST_WORKSPACE_LOCATION} -sa {TEST_WORKSPACE_SA} -o json'), checks=[
             self.check("name", TEST_WORKSPACE_CREATE_DELETE),
             self.check("provisioningState", "Succeeded")
         ])
 
         # delete
-         self.cmd(f'az quantum workspace delete -g {TEST_RG} -w {TEST_WORKSPACE_CREATE_DELETE} -o json'), checks=[
+        self.cmd(f'az quantum workspace delete -g {TEST_RG} -w {TEST_WORKSPACE_CREATE_DELETE} -o json'), checks=[
             self.check("name", TEST_WORKSPACE_CREATE_DELETE),
             self.check("provisioningState", "Deleting")
         ])

--- a/src/quantum/azext_quantum/tests/latest/utils.py
+++ b/src/quantum/azext_quantum/tests/latest/utils.py
@@ -7,7 +7,8 @@ TEST_SUBS = "677fc922-91d0-4bf6-9b06-4274d319a0fa"
 TEST_RG = 'aqua-provider-validator'
 TEST_WORKSPACE = 'validator-workspace-westus'
 TEST_WORKSPACE_CREATE_DELETE = 'validator-workspace-crdl-westus'
-TEST_WORKSPACE_SA = 'validatorsa'
+TEST_WORKSPACE_SA = 'aqvalidatorstorage'
+TEST_WORKSPACE_LOCATION = 'westus'
 
 
 def is_private_preview_subscription(scenario):

--- a/src/quantum/azext_quantum/tests/latest/utils.py
+++ b/src/quantum/azext_quantum/tests/latest/utils.py
@@ -7,6 +7,7 @@ TEST_SUBS = "677fc922-91d0-4bf6-9b06-4274d319a0fa"
 TEST_RG = 'aqua-provider-validator'
 TEST_WORKSPACE = 'validator-workspace-westus'
 TEST_WORKSPACE_CREATE_DELETE = 'validator-workspace-crdl-westus'
+TEST_WORKSPACE_SA = 'validatorsa'
 
 
 def is_private_preview_subscription(scenario):

--- a/src/quantum/azext_quantum/vendored_sdks/azure_mgmt_quantum/operations/workspaces_operations.py
+++ b/src/quantum/azext_quantum/vendored_sdks/azure_mgmt_quantum/operations/workspaces_operations.py
@@ -126,12 +126,35 @@ class WorkspacesOperations(object):
         if self.config.accept_language is not None:
             header_parameters['accept-language'] = self._serialize.header("self.config.accept_language", self.config.accept_language, 'str')
 
+        print("A")
+
         # Construct body
         body_content = self._serialize.body(quantum_workspace, 'QuantumWorkspace')
 
+        print("B")
+
         # Construct and send request
         request = self._client.put(url, query_parameters, header_parameters, body_content)
-        response = self._client.send(request, stream=False, **operation_config)
+
+        print("Inner request:")
+        print(request)
+
+        print(url)
+        print(query_parameters)
+        print(header_parameters)
+        print(body_content)
+
+        print("C")
+
+        try:
+            response = self._client.send(request, stream=False, **operation_config)
+        except Exception as e:
+            print(e)
+            print("Exception end")
+            return
+
+        print("Inner response:")
+        print(response)
 
         if response.status_code not in [200, 201]:
             raise models.ErrorResponseException(self._deserialize, response)
@@ -182,6 +205,10 @@ class WorkspacesOperations(object):
             **operation_config
         )
 
+        print("Raw: ")
+        print(raw_result)
+        print("Deserialized: ")
+
         def get_long_running_output(response):
             deserialized = self._deserialize('QuantumWorkspace', response)
 
@@ -190,6 +217,8 @@ class WorkspacesOperations(object):
                 return client_raw_response
 
             return deserialized
+
+        print(get_long_running_output(raw_result))
 
         lro_delay = operation_config.get(
             'long_running_operation_timeout',

--- a/src/quantum/azext_quantum/vendored_sdks/azure_mgmt_quantum/operations/workspaces_operations.py
+++ b/src/quantum/azext_quantum/vendored_sdks/azure_mgmt_quantum/operations/workspaces_operations.py
@@ -126,35 +126,12 @@ class WorkspacesOperations(object):
         if self.config.accept_language is not None:
             header_parameters['accept-language'] = self._serialize.header("self.config.accept_language", self.config.accept_language, 'str')
 
-        print("A")
-
         # Construct body
         body_content = self._serialize.body(quantum_workspace, 'QuantumWorkspace')
 
-        print("B")
-
         # Construct and send request
         request = self._client.put(url, query_parameters, header_parameters, body_content)
-
-        print("Inner request:")
-        print(request)
-
-        print(url)
-        print(query_parameters)
-        print(header_parameters)
-        print(body_content)
-
-        print("C")
-
-        try:
-            response = self._client.send(request, stream=False, **operation_config)
-        except Exception as e:
-            print(e)
-            print("Exception end")
-            return
-
-        print("Inner response:")
-        print(response)
+        response = self._client.send(request, stream=False, **operation_config)
 
         if response.status_code not in [200, 201]:
             raise models.ErrorResponseException(self._deserialize, response)
@@ -205,10 +182,6 @@ class WorkspacesOperations(object):
             **operation_config
         )
 
-        print("Raw: ")
-        print(raw_result)
-        print("Deserialized: ")
-
         def get_long_running_output(response):
             deserialized = self._deserialize('QuantumWorkspace', response)
 
@@ -217,8 +190,6 @@ class WorkspacesOperations(object):
                 return client_raw_response
 
             return deserialized
-
-        print(get_long_running_output(raw_result))
 
         lro_delay = operation_config.get(
             'long_running_operation_timeout',


### PR DESCRIPTION
Adding initial implementation of 'az quantum workspace create' command.

_________________
Command
    az quantum workspace create : Creates a new Azure Quantum workspace.
        Command group 'quantum' is in preview. It may be changed/removed in a future
        release.
Arguments
    --location -l         : Location. Values from: `az account list-locations`. You can configure
                            the default location using `az configure --defaults
                            location=<location>`.
    --resource-group -g   : Name of resource group. You can configure the default group using `az
                            configure --defaults group=<name>`.
    --storage_account -sa : Name of the storage account to be used by a quantum workspace.
    --workspace-name -w   : Name of the Quantum Workspace. You can configure the default workspace
                            using `az quantum workspace set`.